### PR TITLE
Alias + reprex for libpython-clj analysis error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .clerk
 .nrepl-port
 *.iml
+/classes/

--- a/deps.edn
+++ b/deps.edn
@@ -6,4 +6,14 @@
   io.github.latte-central/LaTTe {:git/sha "521d7f5e02bdec133a251d9dfbdbac6c42481eb7"}
   potemkin/potemkin {:mvn/version "0.4.6"}
   com.layerware/hugsql {:mvn/version "0.5.1"}
-  com.rpl/specter {:mvn/version "1.1.4"}}}
+  com.rpl/specter {:mvn/version "1.1.4"}}
+
+ :aliases
+ {:libpython-clj
+  {:extra-paths ["py-clj-src"]
+   :extra-deps
+   {clj-python/libpython-clj {:mvn/version "2.020"}}
+   ;; JVM config for JDK17 usage of libpython-clj2
+   :jvm-opts  ["--add-modules" "jdk.incubator.foreign"
+               "--enable-native-access=ALL-UNNAMED"]}}
+ }

--- a/py_clj_src/libpython_clj.clj
+++ b/py_clj_src/libpython_clj.clj
@@ -1,0 +1,29 @@
+(ns libpython-clj
+  (:require [libpython-clj2.python :as py]
+            [libpython-clj2.require :refer [require-python]]
+            [nextjournal.clerk :as clerk]))
+
+(py/initialize!)
+
+(require-python '[re])
+
+(let [ptrn (re/compile "pattern")]
+
+  (py/py. ptrn search "pattern"))
+
+(comment
+
+  ;; The alter-var-root workaround will not work if called before require-python
+  (do
+    (alter-var-root #'nextjournal.clerk.analyzer/throw-if-dep-is-missing (constantly (fn [_ _ _])))
+    (clerk/show! "py_clj_src/libpython_clj.clj"))
+
+
+  ;; But if require-python is called before analysis, it will work as expected
+  ;; even without alter-var-root
+  (do
+    (require-python '[re])
+    (clerk/show! "py_clj_src/libpython_clj.clj")
+    )
+
+  )


### PR DESCRIPTION
# Problem statement
Binding Python namespaces into a Clojure namespace using `libpython-clj`'s `require-python` is not compatible with Clerk's analysis on the first pass.

# Reproducing the problem
Launch a REPL with the `:libpython-clj` alias. The first `do` block in the comment form should fail. The second will succeed.

# Identified workaround
If `require-python` is called before `clerk/show!`, then analysis will succeed for this reprex. I haven't yet tested this workaround with more complex `libpython-clj` notebooks. If I identify other issues I will either update this PR or make an additional one.

# Caveats
Only tested on JDK17, other JVM versions might cause issues. See [discussion on libpython-clj's repo](https://github.com/clj-python/libpython-clj/issues/212#issuecomment-1234751552) for additional context.